### PR TITLE
Simplify modman + fix it by removing composer.json symlink

### DIFF
--- a/modman
+++ b/modman
@@ -1,14 +1,5 @@
-app/design/adminhtml/default/default/template/optimiseweb/redirects/system/config/fieldset/hint.phtml app/design/adminhtml/default/default/template/optimiseweb/redirects/system/config/fieldset/hint.phtml
+app/design/adminhtml/default/default/template/optimiseweb/redirects app/design/adminhtml/default/default/template/optimiseweb/redirects
 app/etc/modules/Optimiseweb_Redirects.xml app/etc/modules/Optimiseweb_Redirects.xml
-app/code/community/Optimiseweb/Redirects/Helper/Data.php app/code/community/Optimiseweb/Redirects/Helper/Data.php
-app/code/community/Optimiseweb/Redirects/Model/Redirector.php app/code/community/Optimiseweb/Redirects/Model/Redirector.php
-app/code/community/Optimiseweb/Redirects/Block/Adminhtml/System/Config/Fieldset/Hint.php app/code/community/Optimiseweb/Redirects/Block/Adminhtml/System/Config/Fieldset/Hint.php
-app/code/community/Optimiseweb/Redirects/Block/System/Config/Backend/Download1.php app/code/community/Optimiseweb/Redirects/Block/System/Config/Backend/Download1.php
-app/code/community/Optimiseweb/Redirects/Block/System/Config/Backend/Downloadquerystringfile.php app/code/community/Optimiseweb/Redirects/Block/System/Config/Backend/Downloadquerystringfile.php
-app/code/community/Optimiseweb/Redirects/Block/System/Config/Backend/Download.php app/code/community/Optimiseweb/Redirects/Block/System/Config/Backend/Download.php
-app/code/community/Optimiseweb/Redirects/etc/config.xml app/code/community/Optimiseweb/Redirects/etc/config.xml
-app/code/community/Optimiseweb/Redirects/etc/system.xml app/code/community/Optimiseweb/Redirects/etc/system.xml
-app/code/community/Optimiseweb/Redirects/etc/adminhtml.xml app/code/community/Optimiseweb/Redirects/etc/adminhtml.xml
-app/code/community/Optimiseweb/Redirects/doc/Readme.html app/code/community/Optimiseweb/Redirects/doc/Readme.html
+app/code/community/Optimiseweb/Redirects app/code/community/Optimiseweb/Redirects
 app/locale/en_US/Optimiseweb_Redirects.csv app/locale/en_US/Optimiseweb_Redirects.csv
-composer.json composer.json
+


### PR DESCRIPTION
I have simplified the `modman` file.

* I used the directory instead of each file in it
* I removed the `composer.json` because it is not required at all, and if the project's `composer.json` is next to your `index.php`, it will be override by yours. Which is… a bad thing :p.

Thanks.